### PR TITLE
feat: add output_file_symlink functionality

### DIFF
--- a/nf_workflow.nf
+++ b/nf_workflow.nf
@@ -69,6 +69,7 @@ process CLUSTERING {
     file "results/*txt" optional true
     file "results/*db" optional true
     file "results/*bin" optional true
+    file "results/output_file_symlink/*" optional true
 
     // This is necessary because the glibc libraries are not always used in the conda environment, and defaults to the system which could be old
     beforeScript 'export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$CONDA_PREFIX/lib'

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -1,7 +1,7 @@
 workflowname: incremental_clustering_nextflow_workflow
 workflowdescription: incremental_clustering_nextflow_workflow
 workflowlongdescription: This is the incremental_clustering_nextflow_workflow
-workflowversion: "2025.7.18"
+workflowversion: "2025.8.6"
 workflowfile: nf_workflow.nf
 workflowautohide: false
 adminonly: false


### PR DESCRIPTION
- Add symlink creation for all original scan file paths in finalize_results()
- Create output_file_symlink directory containing symlinks to original mzML files
- Update nf_workflow.nf to include symlink directory in output
- Update workflow version to 2025.8.6
Beta server test link: https://beta.gnps2.org/status?task=e88038b3ccb842bab81519cca061e84e